### PR TITLE
change fields of Node to UInt32

### DIFF
--- a/binarytrees/binarytree-fast.jl
+++ b/binarytrees/binarytree-fast.jl
@@ -6,8 +6,8 @@
 
 using Printf
 struct Node
-    left::Int
-    right::Int
+    left::UInt32
+    right::UInt32
 end
 function alloc!(pool, left, right)
     push!(pool, Node(left, right))
@@ -18,7 +18,7 @@ function make(pool, d)
     alloc!(pool, make(pool, d - 1), make(pool, d - 1))
 end
 check(pool, t::Node) = 1 + check(pool, t.left) + check(pool, t.right)
-function check(pool, node::Int)
+function check(pool, node::Integer)
     node == 0 && return 1
     @inbounds return check(pool, pool[node])
 end


### PR DESCRIPTION
for `depth<=32`, it suffices to index the nodes by UInt32. Saves some memory, and slightly faster on my machine (measured with `@benchmark`):
```
  mean time:        4.367 s (1.46% GC) --> version on master
  mean time:        4.051 s (0.81% GC) --> version on pull request

```