### PR TITLE
Tweak mandelbrot-fast.jl for performance.

### DIFF
--- a/mandelbrot/mandelbrot-fast.jl
+++ b/mandelbrot/mandelbrot-fast.jl
@@ -8,7 +8,7 @@ The Computer Language Benchmarks Game
  modified for Julia 1.0 by Simon Danisch.
  tweaked for performance by https://github.com/maltezfaria and Adam Beckmeyer.
 =#
-const zerov8 = ntuple(x-> 0f0, 8)
+const zerov8 = ntuple(x-> 0.0, 8)
 const masks = (0b01111111, 0b10111111, 0b11011111, 0b11101111, 0b11110111,
                0b11111011, 0b11111101, 0b11111110)
 
@@ -19,13 +19,13 @@ Base.@propagate_inbounds function mand8(cr, ci)
 
     for _=1:10
         for _=1:5
-            Zi = 2f0 .* Zr .* Zi .+ ci
+            Zi = 2.0 .* Zr .* Zi .+ ci
             Zr = Tr .- Ti .+ cr
             Tr = Zr .* Zr
             Ti = Zi .* Zi
         end
         t = Tr .+ Ti
-        all(x-> x > 4f0, t) && (return 0x00)
+        all(x-> x > 4.0, t) && (return 0x00)
     end
 
     byte = 0xff
@@ -44,8 +44,8 @@ end
 
 function mandelbrot(io, n = 200)
     inv_ = 2.0 / n
-    xvals = Vector{Float32}(undef, n)
-    yvals = Vector{Float32}(undef, n)
+    xvals = Vector{Float64}(undef, n)
+    yvals = Vector{Float64}(undef, n)
     @inbounds for i in 0:(n-1)
         xvals[i + 1] = i * inv_ - 1.5
         yvals[i + 1] = i * inv_ - 1.0

--- a/mandelbrot/mandelbrot-fast.v2.jl
+++ b/mandelbrot/mandelbrot-fast.v2.jl
@@ -52,13 +52,9 @@ function mandelbrot(io, n = 200)
     end
 
     rows = Vector{UInt8}(undef, n^2 ÷ 8)
-    @sync for y=1:n
+    Threads.@threads for y=1:n
         @inbounds ci = yvals[y]
-        # This allows dynamic scheduling instead of static scheduling
-        # of Threads.@threads macro. See
-        # https://github.com/JuliaLang/julia/issues/21017 . On some
-        # computers this is faster, on others not.
-        Threads.@spawn mandel_inner(rows, ci, y, n, xvals)
+        mandel_inner(rows, ci, y, n, xvals)
     end
     write(io, "P4\n$n $n\n")
     write(io, rows)

--- a/mandelbrot/mandelbrot-fast.v2.jl
+++ b/mandelbrot/mandelbrot-fast.v2.jl
@@ -8,7 +8,7 @@ The Computer Language Benchmarks Game
  modified for Julia 1.0 by Simon Danisch.
  tweaked for performance by https://github.com/maltezfaria and Adam Beckmeyer.
 =#
-const zerov8 = ntuple(x-> 0f0, 8)
+const zerov8 = ntuple(x-> 0.0, 8)
 const masks = (0b01111111, 0b10111111, 0b11011111, 0b11101111, 0b11110111,
                0b11111011, 0b11111101, 0b11111110)
 
@@ -19,13 +19,13 @@ Base.@propagate_inbounds function mand8(cr, ci)
 
     for _=1:10
         for _=1:5
-            Zi = 2f0 .* Zr .* Zi .+ ci
+            Zi = 2.0 .* Zr .* Zi .+ ci
             Zr = Tr .- Ti .+ cr
             Tr = Zr .* Zr
             Ti = Zi .* Zi
         end
         t = Tr .+ Ti
-        all(x-> x > 4f0, t) && (return 0x00)
+        all(x-> x > 4.0, t) && (return 0x00)
     end
 
     byte = 0xff
@@ -44,8 +44,8 @@ end
 
 function mandelbrot(io, n = 200)
     inv_ = 2.0 / n
-    xvals = Vector{Float32}(undef, n)
-    yvals = Vector{Float32}(undef, n)
+    xvals = Vector{Float64}(undef, n)
+    yvals = Vector{Float64}(undef, n)
     @inbounds for i in 0:(n-1)
         xvals[i + 1] = i * inv_ - 1.5
         yvals[i + 1] = i * inv_ - 1.0

--- a/mandelbrot/mandelbrot-fast.v3.jl
+++ b/mandelbrot/mandelbrot-fast.v3.jl
@@ -10,7 +10,7 @@ The Computer Language Benchmarks Game
 =#
 using KissThreading
 
-const zerov8 = ntuple(x-> 0f0, 8)
+const zerov8 = ntuple(x-> 0.0, 8)
 const masks = (0b01111111, 0b10111111, 0b11011111, 0b11101111, 0b11110111,
                0b11111011, 0b11111101, 0b11111110)
 
@@ -21,13 +21,13 @@ Base.@propagate_inbounds function mand8(cr, ci)
 
     for _=1:10
         for _=1:5
-            Zi = 2f0 .* Zr .* Zi .+ ci
+            Zi = 2.0 .* Zr .* Zi .+ ci
             Zr = Tr .- Ti .+ cr
             Tr = Zr .* Zr
             Ti = Zi .* Zi
         end
         t = Tr .+ Ti
-        all(x-> x > 4f0, t) && (return 0x00)
+        all(x-> x > 4.0, t) && (return 0x00)
     end
 
     byte = 0xff
@@ -46,8 +46,8 @@ end
 
 function mandelbrot(io, n = 200)
     inv_ = 2.0 / n
-    xvals = Vector{Float32}(undef, n)
-    yvals = Vector{Float32}(undef, n)
+    xvals = Vector{Float64}(undef, n)
+    yvals = Vector{Float64}(undef, n)
     @inbounds for i in 0:(n-1)
         xvals[i + 1] = i * inv_ - 1.5
         yvals[i + 1] = i * inv_ - 1.0


### PR DESCRIPTION
Multiple versions with different threadings included because different versions are faster depending on the machine. Depending on machine, gains can be over 20% compared to original mandelbrot-fast.jl.

I would appreciate input on relative timings for each of the scripts others see on their computer. For example, I get the following timings on two of my machines using `hyperfine`:

| | laptop with Intel(R) Core(TM) i5-5300U CPU @ 2.30GHz | desktop with Intel(R) Core(TM) i5-3470 CPU @ 3.20GHz | desktop with Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz |
|-|-|-|-|
| mandelbrot-fast.jl (original) | 2.492 | 1.864 | 1.788 |
| mandelbrot-fast.jl | 2.426 | 1.494 | 1.401 |
| mandelbrot-fast.v2.jl | 2.391 | 1.802 | 1.718 |
| mandelbrot-fast.v3.jl | 2.377 | 1.543 | 1.448 |
| | | | |
| Best | mandelbrot-fast.v3.jl | mandelbrot-fast.jl | mandelbrot-fast.jl |

NOTE: running mandelbrot-fast.v3.jl requires installation of https://github.com/mohamed82008/KissThreading.jl

Changes included in every version:
- Removing threading from filling xvals and yvals--threading overhead is too high for such a simple operation.
- Remove `@simd` annotation from mandel_inner--simd is occurring at the level of mand8; `@simd` doesn't hurt runtime but increases compilation time.
- Only run mandelbrot when !isinteractive() to make development and debugging easier.
- Various tweaks and minor stylistic updates for succinctness and maybe a marginal increase in performance.
